### PR TITLE
Prepare README for React Apollo FR migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# Apollo Client Feature Requests
+# <a href='https://www.apollographql.com/'><img src='https://user-images.githubusercontent.com/841294/53402609-b97a2180-39ba-11e9-8100-812bab86357c.png' height='100' alt='Apollo Feature Requests'></a>
 
-This repository is used to track [Apollo Client](https://github.com/apollographql/apollo-client) feature requests and discussions. Click [here](https://github.com/apollographql/apollo-feature-requests/issues/new) to open a new feature request.
+## Apollo Feature Requests
 
-**Note:** Apollo Client bugs are tracked in the [Apollo Client repo issue tracker](https://github.com/apollographql/apollo-client/issues).
+This repository is used to track [Apollo Client](https://github.com/apollographql/apollo-client) and [React Apollo](https://github.com/apollographql/react-apollo) feature requests and discussions. Click [here](https://github.com/apollographql/apollo-feature-requests/issues/new) to open a new feature request.
 
-## Suggesting Features
+> **Note:** Apollo Client / React Apollo bugs are tracked in the each project's GitHub issue tracker:
+> 
+> - [Apollo Client issue tracker](https://github.com/apollographql/apollo-client/issues)
+> - [React Apollo issue tracker](https://github.com/apollographql/react-apollo/issues)
+
+### Suggesting Features
 
 Most of the features in Apollo came from suggestions by you, the community! We welcome any ideas about how to make Apollo better for your use case. Unless there is overwhelming demand for a feature, it might not get implemented immediately, but please include as much information as possible that will help people have a discussion about your proposal:
 
@@ -18,9 +23,9 @@ Please keep in mind that feature requests should be well specified and unambiguo
 
 The [issues](https://github.com/apollographql/apollo-feature-requests/issues/) area of this repo should be used to discuss new features and possible implementation designs. You can show your support for (or against!) features by using GitHub reactions, or by adding meaningful details which help the feature definition become more clear. Please do not comment with "+1" as it creates a lot of noise (e-mails, notifications, etc.).
 
-Please refrain from submitting a pull request in the main [Apollo Client repo](https://github.com/apollographql/apollo-client), to implement a proposed feature, until there is consensus that it should be included. This way, you can avoid putting in work that can’t be merged in. Once there is a consensus on the need for a new feature, proceed as listed in the [Apollo Client CONTRIBUTING doc](https://github.com/apollographql/apollo-client/blob/master/CONTRIBUTING.md#big-prs).
+Please refrain from submitting a pull request in the [Apollo Client](https://github.com/apollographql/apollo-client) or [React Apollo](https://github.com/apollographql/apollo-client) repos, to implement a proposed feature, until there is consensus that it should be included. This way, you can avoid putting in work that can’t be merged in. Once there is a consensus on the need for a new feature, proceed as listed in the [CONTRIBUTING doc](https://github.com/apollographql/apollo-client/blob/master/CONTRIBUTING.md#big-prs).
 
-## Feature Request Issue Triage
+### Feature Request Issue Triage
 
 1. For reasons described [above](#suggesting-features), we would prefer features to be built as separate packages. If the feature can clearly be built as a package, explain this to the requester and close the issue.
 > - If the feature could be built as a package and serves a particular need, encourage the user to contribute it themselves.
@@ -31,7 +36,8 @@ Please refrain from submitting a pull request in the main [Apollo Client repo](h
 
 Core contributors may add the `help-wanted` label to feature requests. This indicates the feature is aligned with the project roadmap and a high-quality pull request will almost certainly be merged.
 
-## Resources
+### Resources
 
 - [Main Apollo Client repo](https://github.com/apollographql/apollo-client)
+- [Main React Apollo repo](https://github.com/apollographql/react-apollo)
 - [Contribution guidelines](https://github.com/apollographql/apollo-client/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
We'll be migrating React Apollo feature requests to this repo shortly, so this PR prepares the README.