### PR TITLE
Update README to specify this is an apollo client feature request repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,22 @@ Before making a feature request here please consider the following:
 ## 🌎 Community involvement
 
 The [issues](https://github.com/apollographql/apollo-feature-requests/issues/) area of this repository should be used to discuss new features and possible implementation designs. You can show your support for (or against!) features by using GitHub reactions, or by adding meaningful details which help the feature definition become more clear. Please do not comment with "+1" as it creates a lot of noise (e-mails, notifications, etc.).
+
+## Core platform feature requests
+
+This repository used to track feature requests across the entire supergraph core platform. If you're coming here to request a feature outside of Apollo Client, please open an issue in the respective repository instead.
+
+### Clients
+
+- [Apollo Client: iOS](https://github.com/apollographql/apollo-ios)
+- [Apollo Client: Kotlin](https://github.com/apollographql/apollo-kotlin)
+
+### Router / Federation
+
+- [Apollo Router](https://github.com/apollographql/router)
+- [Apollo Federation](https://github.com/apollographql/federation)
+- [Apollo Federation Subgraph Compatibility](https://github.com/apollographql/apollo-federation-subgraph-compatibility)
+
+### Compose / Publish
+
+- [Apollo Rover CLI](https://github.com/apollographql/rover)

--- a/README.md
+++ b/README.md
@@ -2,29 +2,11 @@
 
 # 👋 Welcome
 
-Many of the features in the core Apollo projects came from suggestions by you, the community! While each project has it's own repo for tracking issues, we welcome any ideas about how to make the end-to-end supergraph experience across the core projects work better for your use cases. Unless there is overwhelming demand for a feature, it might not get implemented immediately, but please include as much information as possible that will help people have a discussion about your proposal.
+Many of the features in the Apollo Client library came from suggestions by you, the community! While the project has it's own repo for tracking issues, we welcome any ideas about how to make the experience for the client better for your use cases. Unless there is overwhelming demand for a feature, it might not get implemented immediately, but please include as much information as possible that will help people have a discussion about your proposal.
 
 ## 🧑‍🚀 Apollo feature request process
 
-This repository is used to track end-to-end supergraph feature requests across the entire core platform. This includes our subgraph compatibility project that ensures your subgraph library or hosted GraphQL API works seamlessly as part of your supergraph, powered by these core projects:
-
-### Clients
-
-- [Apollo Client: iOS](https://github.com/apollographql/apollo-ios)
-- [Apollo Client: Kotlin](https://github.com/apollographql/apollo-kotlin)
-- [Apollo Client: Web](https://github.com/apollographql/apollo-client)
-
-### Router / Federation
-
-- [Apollo Router](https://github.com/apollographql/router)
-- [Apollo Federation](https://github.com/apollographql/federation)
-- [Apollo Federation Subgraph Compatibility](https://github.com/apollographql/apollo-federation-subgraph-compatibility)
-
-### Compose / Publish
-
-- [Apollo Rover CLI](https://github.com/apollographql/rover)
-
-With the intention of focusing this repository on the entire core platform of Apollo, not the individual projects themselves.
+This repository is used to track [Apollo Client](https://github.com/apollographql/apollo-client) feature requests.
 
 Just Click 👉 [here](https://github.com/apollographql/apollo-feature-requests/issues/new) to open a new feature request!
 
@@ -32,25 +14,17 @@ Just Click 👉 [here](https://github.com/apollographql/apollo-feature-requests/
 
 Before making a feature request here please consider the following:
 
-1. Is there already an individual issue or PR covering this feature in one of the other open source project repositories?
+1. Does this feature request support a wide range of use cases or is it uniquely specific to your individual use case?
 
-  > Please check the other open source projects before creating a new feature request. Try to link any related issues or PRS in other repositories to the new feature request.
+> If it's unique to you, this may not be an ideal feature for the entire client. Feel free to ask for help or advice in our [Discord server](https://discord.gg/graphos).
 
-2. Is this feature and end to end core platform feature, or individual project level feature?
+2. Is this just a question or discussion on how to do something in the Apollo Platform?
 
-  > If it's specific to a individual project, it's better to report the issue in that specific project, only. See links to repositories above.
+> If so, this might make a better post in our [Community Forum](https://community.apollographql.com/) or [Discord server](https://discord.gg/graphos)
 
-3. Does this feature request support a wide range of use cases or is it uniquely specific to your individual use case?
+3. Is there a work around available to you?
 
-  > If it's unique to you, this may not be an ideal feature for the entire platform to consider.
-
-4. Is this just a question or discussion on how to do something in the Apollo Platform?
-
-  > If so, this might make a better post in our [Community Forum](https://community.apollographql.com/)
-
-5. Is there a work around available to you?
-
-  > Is this a more convenient way to do something that is already possible, or is there some blocker that makes a workaround unfeasible?
+> Is this a more convenient way to do something that is already possible, or is there some blocker that makes a workaround unfeasible?
 
 ## 🌎 Community involvement
 


### PR DESCRIPTION
After discussion with several teams, including the Apollo Client team, we decided that each team wants to keep feature requests in their respective repos, while the Apollo Client team will keep this repo for feature requests. This PR updates the README to reflect this change in philosophy.

[Rendered updated README](https://github.com/apollographql/apollo-feature-requests/blob/update-readme/README.md)